### PR TITLE
migrate from fig to docker-compose

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,7 @@
     "new-cap": 2,
     "no-spaced-func": 2,
     "no-space-before-semi": 2,
-    "space-unary-word-ops": 2,
+    "space-unary-ops": 2,
     "quotes": [2, "single"]
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM quay.io/yldio/paz-base
 
 WORKDIR /usr/src/app
 

--- a/bin/server
+++ b/bin/server
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 node server.js "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+svcdir:
+  build: .
+  environment:
+    - PAZ_SERVICE_DIRECTORY_PORT=9001
+  ports:
+    - "9001:9001"

--- a/fig.yml
+++ b/fig.yml
@@ -1,7 +1,0 @@
-svcdir:
-  build: .
-  environment:
-   - PAZ_SERVICE_DIRECTORY_PORT=9001
-  ports:
-   - "9001:9001"
-

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "codestyle": "jscs -p google bin/ lib/ middleware/ resources/ server.js",
-    "test": "fig up -d && sleep 5 && lab && fig stop",
+    "test": "docker-compose build && docker-compose up -d && sleep 3 && lab && docker-compose stop",
     "docs": "mkdir -p docs/generated && aglio -i docs/api-blueprint.md -o docs/generated/index.html",
     "docs-server": "st -p 9002 -d docs/generated -i index.html"
   },
@@ -28,7 +28,9 @@
   },
   "devDependencies": {
     "aglio": "^1.14.0",
+    "eslint": "^0.21.2",
     "expectations": "^0.2.5",
+    "jscs": "^1.13.1",
     "json-override": "^0.1.2",
     "lab": "^4.4.4",
     "mocha": "^1.18.2",

--- a/resources/service/controller.js
+++ b/resources/service/controller.js
@@ -6,8 +6,7 @@ module.exports = function(cfg) {
     service.validate(req.body, req._uuid, function(err) {
       if (err) {
         res.send(err.statusCode, err);
-      }
-      else {
+      } else {
         next();
       }
     });
@@ -17,8 +16,7 @@ module.exports = function(cfg) {
     service.validateConfigPatch(req.body, req._uuid, function(err) {
       if (err) {
         res.send(err.statusCode || 500, err);
-      }
-      else {
+      } else {
         next();
       }
     });
@@ -37,8 +35,7 @@ module.exports = function(cfg) {
         function(err, response) {
           if (err) {
             res.send(err.statusCode || 500, err.message);
-          }
-          else {
+          } else {
             res.send(response ? 200 : 404, response);
           }
         });
@@ -58,8 +55,7 @@ module.exports = function(cfg) {
         function(err, response) {
           if (err) {
             res.send(err.statusCode || 500, err.message);
-          }
-          else {
+          } else {
             res.send(200, response);
           }
         });
@@ -67,7 +63,7 @@ module.exports = function(cfg) {
 
   controller.create = function(req, res) {
     req.log.info({
-      'service.create':'*',
+      'service.create': '*',
       'uuid': req._uuid
     });
 
@@ -78,8 +74,7 @@ module.exports = function(cfg) {
     function(err, response) {
       if (err) {
         res.send(err.statusCode || 500, err.message);
-      }
-      else {
+      } else {
         res.send(201, response);
       }
     });
@@ -99,8 +94,7 @@ module.exports = function(cfg) {
     function(err, response) {
       if (err) {
         res.send(err.statusCode, err.message);
-      }
-      else {
+      } else {
         res.send(200, response);
       }
     });
@@ -118,8 +112,7 @@ module.exports = function(cfg) {
     function(err) {
       if (err) {
         res.send(err.statusCode, err.message);
-      }
-      else {
+      } else {
         res.send(204);
       }
     });

--- a/resources/service/model.js
+++ b/resources/service/model.js
@@ -43,8 +43,7 @@ module.exports = function Service(cfg) {
             statusCode: 404,
             message: err.message
           }));
-        }
-        else {
+        } else {
           return cb(new _Error(err, {
             statusCode: 500,
             message: err.message
@@ -64,21 +63,18 @@ module.exports = function Service(cfg) {
     if (params.dockerRepository) {
       // do lookup for service by dockerRepository
       db.get('dockerRepository!' + encodeURIComponent(params.dockerRepository),
-        function(err, serviceKey) {
-          if (err) {
-            if (err.notFound) {
-              return cb(new _Error(err, {statusCode: 404}));
+        function(latestErr, serviceKey) {
+          if (latestErr) {
+            if (latestErr.notFound) {
+              return cb(new _Error(latestErr, {statusCode: 404}));
+            } else {
+              return cb(new _Error(latestErr, {statusCode: 500}));
             }
-            else {
-              return cb(new _Error(err, {statusCode: 500}));
-            }
-          }
-          else {
+          } else {
             db.get(serviceKey, function(err, doc) {
               if (err && err.notFound) {
                 return cb(new _Error(err, {statusCode: 404}));
-              }
-              else if (err) {
+              } else if (err) {
                 return cb(new _Error(err, {statusCode: 500}));
               }
               return cb(null, {
@@ -87,8 +83,7 @@ module.exports = function Service(cfg) {
             });
           }
         });
-    }
-    else {
+    } else {
       db.createReadStream({
         start: 'service!',
         end: 'service!\xff'
@@ -109,8 +104,8 @@ module.exports = function Service(cfg) {
   };
 
   service.create = function(meta, object, cb) {
-    db.get('service!' + object.name, function(err) {
-      if (err && err.notFound) {
+    db.get('service!' + object.name, function(latestErr) {
+      if (latestErr && latestErr.notFound) {
         // only the base keys go in root of object, rest is config, gaps filled by pazDefaults
         var baseKeys = ['name', 'description', 'dockerRepository'];
         var doc = {};
@@ -156,15 +151,14 @@ module.exports = function Service(cfg) {
             doc: doc
           });
         });
-      } else if (err) {
+      } else if (latestErr) {
         return cb(new _Error(
           'Error putting resource',
           {
             statusCode: 500,
             uuid: meta.uuid
           }));
-      }
-      else {
+      } else {
         return cb(new _Error(
           'Error putting resource: a service by that name already exists',
           {
@@ -176,8 +170,8 @@ module.exports = function Service(cfg) {
   };
 
   service.modifyConfig = function(id, meta, object, cb) {
-    db.get('service!' + id, function(err, doc) {
-      if (err && err.notFound) {
+    db.get('service!' + id, function(latestErr, doc) {
+      if (latestErr && latestErr.notFound) {
         return cb(new _Error(
           'Cannot modify service config, a service by that name doesn\'t exist.',
           {
@@ -210,9 +204,9 @@ module.exports = function Service(cfg) {
 
   service.del = function(id, meta, cb) {
     var dbKey = 'service!' + id;
-    db.get(dbKey, function(err, doc) {
-      if (err) {
-        return cb(err.notFound ?
+    db.get(dbKey, function(latestErr, doc) {
+      if (latestErr) {
+        return cb(latestErr.notFound ?
             new _Error('Resource not found', {
               statusCode: 404,
               uuid: meta.uuid
@@ -258,8 +252,7 @@ module.exports = function Service(cfg) {
             statusCode: 404,
             message: err.message
           }));
-        }
-        else {
+        } else {
           return cb(new _Error(err, {
             statusCode: 500,
             message: err.message

--- a/server.js
+++ b/server.js
@@ -24,8 +24,8 @@ if (argh.argv.help || argh.argv.h) {
 var APP_NAME = pkgjson.name.toUpperCase().replace('-', '_');
 var opts = {
   'port': +(argh.argv.port || process.env[APP_NAME + '_PORT'] || '9001'),
-  'loglevel': argh.argv.loglevel || process.env[APP_NAME + '_LOGLEVEL']  || 'info',
-  'dbname': argh.argv.dbname || process.env[APP_NAME + '_DBNAME']  || 'db'
+  'loglevel': argh.argv.loglevel || process.env[APP_NAME + '_LOGLEVEL'] || 'info',
+  'dbname': argh.argv.dbname || process.env[APP_NAME + '_DBNAME'] || 'db'
 };
 
 var dbPath = opts.dbname;

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-  'use strict';
+'use strict';
 
 /* eslint-disable no-unused-expressions */
 
@@ -91,9 +91,9 @@ lab.experiment('Service Directory', function() {
       .send(service)
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')
-      .end(function(err) {
-        if (err) {
-          return done(err);
+      .end(function(latestErr) {
+        if (latestErr) {
+          return done(latestErr);
         }
 
         svcDir
@@ -126,9 +126,9 @@ lab.experiment('Service Directory', function() {
       .send(service)
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')
-      .end(function(err) {
-        if (err) {
-          return done(err);
+      .end(function(latestErr) {
+        if (latestErr) {
+          return done(latestErr);
         }
 
         // now fetch it
@@ -172,9 +172,9 @@ lab.experiment('Service Directory', function() {
       .send(service)
       .set('Content-Type', 'application/json')
       .set('Accept', 'application/json')
-      .end(function(err) {
-        if (err) {
-          return done(err);
+      .end(function(latestErr) {
+        if (latestErr) {
+          return done(latestErr);
         }
 
         svcDir


### PR DESCRIPTION
For more details see: paz-sh/paz-orchestrator#8
closes #5 #6

:musical_note: [A-Yue【改變 Changes】](https://www.youtube.com/watch?v=tn4qgbWmqYE)

``` bash
$ sudo npm test

> paz-service-directory@0.0.1 test /home/jacyzon/Project/paz/paz-service-directory
> docker-compose build && docker-compose up -d && sleep 3 && lab && docker-compose stop

Building svcdir...
Step 0 : FROM quay.io/yldio/paz-base
 ---> 835e00fc327f
Step 1 : WORKDIR /usr/src/app
 ---> Using cache
 ---> acfbff95d59f
Step 2 : ADD ./package.json /usr/src/app/package.json
 ---> f7a11b3d76d7
Removing intermediate container f7b9ff324d55
Step 3 : RUN npm install
 ---> Running in 343b163986d5
npm WARN package.json paz-service-directory@0.0.1 No repository field.
npm WARN package.json paz-service-directory@0.0.1 No README data

> precommit-hook@1.0.7 install /usr/src/app/node_modules/precommit-hook
> hook_install

This project doesn't appear to be a git repository. To enable the pre-commit hook, run `git init` followed by `npm run precommit-hook install`.

> dtrace-provider@0.2.8 install /usr/src/app/node_modules/bunyan/node_modules/dtrace-provider
> node-gyp rebuild

make: Entering directory '/usr/src/app/node_modules/bunyan/node_modules/dtrace-provider/build'
  TOUCH Release/obj.target/DTraceProviderStub.stamp
make: Leaving directory '/usr/src/app/node_modules/bunyan/node_modules/dtrace-provider/build'
npm WARN optional dep failed, continuing fsevents@0.3.6

> dtrace-provider@0.3.2 install /usr/src/app/node_modules/restify/node_modules/dtrace-provider
> node scripts/install.js


> leveldown@0.10.5 install /usr/src/app/node_modules/leveldown
> node-gyp rebuild

make: Entering directory '/usr/src/app/node_modules/leveldown/build'
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/builder.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/db_impl.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/db_iter.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/filename.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/dbformat.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/log_reader.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/log_writer.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/memtable.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/repair.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/table_cache.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/version_edit.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/version_set.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/db/write_batch.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/helpers/memenv/memenv.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/block.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/block_builder.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/filter_block.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/format.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/iterator.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/merger.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/table.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/table_builder.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/table/two_level_iterator.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/arena.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/bloom.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/cache.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/coding.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/comparator.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/crc32c.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/env.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/filter_policy.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/hash.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/logging.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/options.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/status.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/port/port_posix.o
  CXX(target) Release/obj.target/leveldb/deps/leveldb/leveldb-1.14.0/util/env_posix.o
  AR(target) Release/obj.target/deps/leveldb/leveldb.a
  COPY Release/leveldb.a
  CXX(target) Release/obj.target/snappy/deps/snappy/snappy-1.1.1/snappy-sinksource.o
  CXX(target) Release/obj.target/snappy/deps/snappy/snappy-1.1.1/snappy-stubs-internal.o
  CXX(target) Release/obj.target/snappy/deps/snappy/snappy-1.1.1/snappy.o
  AR(target) Release/obj.target/deps/snappy/snappy.a
  COPY Release/snappy.a
  CXX(target) Release/obj.target/leveldown/src/batch.o
  CXX(target) Release/obj.target/leveldown/src/batch_async.o
  CXX(target) Release/obj.target/leveldown/src/database.o
  CXX(target) Release/obj.target/leveldown/src/database_async.o
  CXX(target) Release/obj.target/leveldown/src/iterator.o
  CXX(target) Release/obj.target/leveldown/src/iterator_async.o
  CXX(target) Release/obj.target/leveldown/src/leveldown.o
  CXX(target) Release/obj.target/leveldown/src/leveldown_async.o
  SOLINK_MODULE(target) Release/obj.target/leveldown.node
  SOLINK_MODULE(target) Release/obj.target/leveldown.node: Finished
  COPY Release/leveldown.node
make: Leaving directory '/usr/src/app/node_modules/leveldown/build'
npm WARN prefer global jshint@2.7.0 should be installed with -g

> dtrace-provider@0.4.0 install /usr/src/app/node_modules/restify/node_modules/bunyan/node_modules/dtrace-provider
> node scripts/install.js


> ws@0.5.0 install /usr/src/app/node_modules/aglio/node_modules/socket.io/node_modules/engine.io/node_modules/ws
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory '/usr/src/app/node_modules/aglio/node_modules/socket.io/node_modules/engine.io/node_modules/ws/build'
  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node: Finished
  COPY Release/bufferutil.node
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/obj.target/validation.node
  SOLINK_MODULE(target) Release/obj.target/validation.node: Finished
  COPY Release/validation.node
make: Leaving directory '/usr/src/app/node_modules/aglio/node_modules/socket.io/node_modules/engine.io/node_modules/ws/build'

> ws@0.4.31 install /usr/src/app/node_modules/aglio/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory '/usr/src/app/node_modules/aglio/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/build'
  CXX(target) Release/obj.target/bufferutil/src/bufferutil.o
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node
  SOLINK_MODULE(target) Release/obj.target/bufferutil.node: Finished
  COPY Release/bufferutil.node
  CXX(target) Release/obj.target/validation/src/validation.o
  SOLINK_MODULE(target) Release/obj.target/validation.node
  SOLINK_MODULE(target) Release/obj.target/validation.node: Finished
  COPY Release/validation.node
make: Leaving directory '/usr/src/app/node_modules/aglio/node_modules/socket.io/node_modules/socket.io-client/node_modules/engine.io-client/node_modules/ws/build'

> protagonist@0.19.6 install /usr/src/app/node_modules/aglio/node_modules/protagonist
> node-gyp rebuild

make: Entering directory '/usr/src/app/node_modules/aglio/node_modules/protagonist/build'
  CXX(target) Release/obj.target/libmarkdownparser/drafter/ext/snowcrash/ext/markdown-parser/src/ByteBuffer.o
  CXX(target) Release/obj.target/libmarkdownparser/drafter/ext/snowcrash/ext/markdown-parser/src/MarkdownNode.o
  CXX(target) Release/obj.target/libmarkdownparser/drafter/ext/snowcrash/ext/markdown-parser/src/MarkdownParser.o
  AR(target) Release/obj.target/drafter/ext/snowcrash/markdownparser.a
  COPY Release/markdownparser.a
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/HTTP.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSON.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONOneOfParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONSourcemap.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONTypeSectionParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/MSONValueMemberParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/Blueprint.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/BlueprintSourcemap.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/Section.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/Signature.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/snowcrash.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/UriTemplateParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/HeadersParser.o
  CXX(target) Release/obj.target/libsnowcrash/drafter/ext/snowcrash/src/posix/RegexMatch.o
  AR(target) Release/obj.target/drafter/ext/snowcrash/snowcrash.a
  COPY Release/snowcrash.a
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/autolink.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/buffer.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/markdown.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/src_map.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/src/stack.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/houdini_href_e.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/houdini_html_e.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/html.o
  CC(target) Release/obj.target/libsundown/drafter/ext/snowcrash/ext/markdown-parser/ext/sundown/html/html_smartypants.o
  AR(target) Release/obj.target/drafter/ext/snowcrash/sundown.a
  COPY Release/sundown.a
  CXX(target) Release/obj.target/libdrafter/drafter/src/drafter.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/cdrafter.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/Serialize.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/SerializeAST.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/SerializeSourcemap.o
  CXX(target) Release/obj.target/libdrafter/drafter/src/SerializeResult.o
  AR(target) Release/obj.target/drafter/drafter.a
  COPY Release/drafter.a
  CXX(target) Release/obj.target/libsos/drafter/ext/sos/src/sos.o
  AR(target) Release/obj.target/drafter/sos.a
  COPY Release/sos.a
  CXX(target) Release/obj.target/protagonist/src/annotation.o
  CXX(target) Release/obj.target/protagonist/src/parse.o
  CXX(target) Release/obj.target/protagonist/src/protagonist.o
  CXX(target) Release/obj.target/protagonist/src/result.o
  CXX(target) Release/obj.target/protagonist/src/v8_wrapper.o
  SOLINK_MODULE(target) Release/obj.target/protagonist.node
  SOLINK_MODULE(target) Release/obj.target/protagonist.node: Finished
  COPY Release/protagonist.node
make: Leaving directory '/usr/src/app/node_modules/aglio/node_modules/protagonist/build'
error-plus@0.0.1 node_modules/error-plus

json-override@0.1.2 node_modules/json-override

ini@1.3.3 node_modules/ini

argh@0.1.3 node_modules/argh

expectations@0.2.5 node_modules/expectations

st@0.5.4 node_modules/st
├── negotiator@0.5.3
├── graceful-fs@3.0.7
├── mime@1.3.4
├── async-cache@0.1.5 (lru-cache@2.3.1)
├── fd@0.0.2
└── bl@0.9.4 (readable-stream@1.0.33)

levelup@0.18.6 node_modules/levelup
├── xtend@3.0.0
├── prr@0.0.0
├── errno@0.1.2
├── bl@0.8.2
├── semver@2.3.2
├── readable-stream@1.0.33 (isarray@0.0.1, string_decoder@0.10.31, core-util-is@1.0.1, inherits@2.0.1)
└── deferred-leveldown@0.2.0 (abstract-leveldown@0.12.4)

supertest@0.12.1 node_modules/supertest
├── methods@1.0.0
└── superagent@0.18.0 (methods@0.0.1, extend@1.2.1, qs@0.6.6, debug@0.7.4, cookiejar@1.3.2, component-emitter@1.1.2, reduce-component@1.0.1, mime@1.2.5, formidable@1.0.14, readable-stream@1.0.27-1, form-data@0.1.2)

mocha@1.21.5 node_modules/mocha
├── escape-string-regexp@1.0.2
├── diff@1.0.8
├── growl@1.8.1
├── commander@2.3.0
├── jade@0.26.3 (commander@0.6.1, mkdirp@0.3.0)
├── debug@2.0.0 (ms@0.6.2)
├── mkdirp@0.5.0 (minimist@0.0.8)
└── glob@3.2.3 (graceful-fs@2.0.3, inherits@2.0.1, minimatch@0.2.14)

bunyan@0.22.3 node_modules/bunyan
├── mv@2.0.3 (rimraf@2.2.8, ncp@0.6.0, mkdirp@0.5.1)
└── dtrace-provider@0.2.8

jscs@1.13.1 node_modules/jscs
├── strip-json-comments@1.0.2
├── pathval@0.1.1
├── commander@2.6.0
├── estraverse@1.9.3
├── vow@0.4.9
├── exit@0.1.2
├── chalk@1.0.0 (escape-string-regexp@1.0.3, ansi-styles@2.0.1, supports-color@1.3.1, strip-ansi@2.0.1, has-ansi@1.0.3)
├── cli-table@0.3.1 (colors@1.0.3)
├── minimatch@2.0.8 (brace-expansion@1.1.0)
├── vow-fs@0.3.4 (vow-queue@0.4.2, node-uuid@1.4.3, glob@4.5.3)
├── glob@5.0.10 (path-is-absolute@1.0.0, inherits@2.0.1, once@1.3.2, inflight@1.0.4)
├── lodash.assign@3.0.0 (lodash._createassigner@3.1.1, lodash._baseassign@3.2.0)
├── esprima-harmony-jscs@1.1.0-bin
├── esprima@1.2.5
├── prompt@0.2.14 (revalidator@0.1.8, pkginfo@0.3.0, read@1.0.6, utile@0.2.1, winston@0.8.3)
└── xmlbuilder@2.6.4 (lodash@3.9.3)

joi@4.9.0 node_modules/joi
├── isemail@1.1.1
├── topo@1.0.2
├── hoek@2.14.0
└── moment@2.10.3

jshint@2.7.0 node_modules/jshint
├── strip-json-comments@1.0.2
├── exit@0.1.2
├── shelljs@0.3.0
├── console-browserify@1.1.0 (date-now@0.1.4)
├── minimatch@2.0.8 (brace-expansion@1.1.0)
├── cli@0.6.6 (glob@3.2.11)
├── htmlparser2@3.8.2 (domelementtype@1.3.0, entities@1.0.0, domhandler@2.3.0, readable-stream@1.1.13, domutils@1.5.1)
└── lodash@3.6.0

precommit-hook@1.0.7 node_modules/precommit-hook

lab@4.7.0 node_modules/lab
├── diff@1.4.0
├── items@1.1.0
├── bossy@1.0.2
├── hoek@2.14.0
├── esprima@1.2.5
├── chai@1.10.0 (assertion-error@1.0.0, deep-eql@0.1.3)
├── source-map-support@0.2.10 (source-map@0.1.32)
├── handlebars@1.3.0 (optimist@0.3.7, uglify-js@2.3.6)
└── eslint@0.8.2 (object-assign@1.0.0, strip-json-comments@1.0.2, estraverse@1.5.1, xml-escape@1.0.0, user-home@1.1.1, text-table@0.2.0, escope@1.0.3, debug@2.2.0, doctrine@0.5.2, chalk@0.5.1, minimatch@1.0.0, mkdirp@0.5.1, optionator@0.4.0, js-yaml@3.2.7)

eslint@0.21.2 node_modules/eslint
├── object-assign@2.0.0
├── escape-string-regexp@1.0.3
├── path-is-absolute@1.0.0
├── strip-json-comments@1.0.2
├── xml-escape@1.0.0
├── user-home@1.1.1
├── estraverse-fb@1.3.1
├── globals@6.4.1
├── estraverse@2.0.0
├── text-table@0.2.0
├── debug@2.2.0 (ms@0.7.1)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── optionator@0.5.0 (type-check@0.3.1, deep-is@0.1.3, levn@0.2.5, wordwrap@0.0.3, prelude-ls@1.1.2, fast-levenshtein@1.0.6)
├── espree@2.0.2
├── chalk@1.0.0 (ansi-styles@2.0.1, supports-color@1.3.1, strip-ansi@2.0.1, has-ansi@1.0.3)
├── concat-stream@1.4.8 (inherits@2.0.1, typedarray@0.0.6, readable-stream@1.1.13)
├── minimatch@2.0.8 (brace-expansion@1.1.0)
├── doctrine@0.6.4 (isarray@0.0.1, esutils@1.1.6)
├── js-yaml@3.3.1 (esprima@2.2.0, argparse@1.0.2)
├── inquirer@0.8.5 (figures@1.3.5, ansi-regex@1.1.1, cli-width@1.0.1, through@2.3.7, readline2@0.1.1, rx@2.5.2, lodash@3.9.3)
└── escope@3.1.0 (esrecurse@3.1.1, estraverse@3.1.0, es6-weak-map@0.1.4, es6-map@0.1.1)

leveldown@0.10.5 node_modules/leveldown
├── bindings@1.2.1
└── nan@1.8.4

restify@2.8.5 node_modules/restify
├── assert-plus@0.1.5
├── escape-regexp-component@1.0.2
├── tunnel-agent@0.4.0
├── deep-equal@0.2.2
├── keep-alive-agent@0.0.1
├── negotiator@0.4.9
├── lru-cache@2.6.4
├── mime@1.3.4
├── formidable@1.0.17
├── qs@1.2.2
├── node-uuid@1.4.3
├── semver@2.3.2
├── spdy@1.32.0
├── once@1.3.2 (wrappy@1.0.1)
├── backoff@2.4.1 (precond@0.2.3)
├── verror@1.6.0 (extsprintf@1.2.0)
├── csv@0.4.2 (stream-transform@0.0.7, csv-parse@0.1.2, csv-generate@0.0.4, csv-stringify@0.0.6)
├── http-signature@0.10.1 (asn1@0.1.11, ctype@0.5.3)
├── dtrace-provider@0.3.2 (nan@1.3.0)
└── bunyan@1.3.5 (safe-json-stringify@1.0.3, mv@2.0.3, dtrace-provider@0.4.0)

aglio@1.18.0 node_modules/aglio
├── yargs@1.3.3
├── coffee-script@1.9.3
├── chokidar@0.12.6 (async-each@0.1.6, readdirp@1.3.0)
├── highlight.js@8.6.0
├── stylus@0.49.3 (css-parse@1.7.0, mkdirp@0.3.5, debug@2.2.0, source-map@0.1.43, glob@3.2.11, sax@0.5.8)
├── remarkable@1.6.0 (autolinker@0.15.3, argparse@0.1.16)
├── jade@1.10.0 (character-parser@1.2.1, void-elements@2.0.1, commander@2.6.0, mkdirp@0.5.1, jstransformer@0.0.2, with@4.0.3, transformers@2.1.0, uglify-js@2.4.23, constantinople@3.0.1, clean-css@3.2.10)
├── cli-color@0.3.3 (d@0.1.1, timers-ext@0.1.0, memoizee@0.3.8, es5-ext@0.10.7)
├── moment@2.10.3
├── socket.io@1.3.5 (debug@2.1.0, has-binary-data@0.1.3, socket.io-adapter@0.3.1, socket.io-parser@2.2.4, engine.io@1.5.1, socket.io-client@1.3.5)
└── protagonist@0.19.6 (nan@1.8.4)
 ---> a3b6e40c473f
Removing intermediate container 343b163986d5
Step 4 : ADD ./bin /usr/src/app/bin
 ---> 58ecb243cfe7
Removing intermediate container 7add7966602c
Step 5 : ADD ./lib /usr/src/app/lib
 ---> dd96c737bbb6
Removing intermediate container 498358d53161
Step 6 : ADD ./middleware /usr/src/app/middleware
 ---> 293457732bd5
Removing intermediate container 9f89f59e2c86
Step 7 : ADD ./resources /usr/src/app/resources
 ---> e5eccb924448
Removing intermediate container c75efeaa5b32
Step 8 : ADD ./test /usr/src/app/test
 ---> 87ae95834993
Removing intermediate container 687ac3452072
Step 9 : ADD ./server.js /usr/src/app/server.js
 ---> a70e3642f0b0
Removing intermediate container a90f9b082c9b
Step 10 : EXPOSE 9001
 ---> Running in 5b0c0b9cc1d4
 ---> 0e2754f845b4
Removing intermediate container 5b0c0b9cc1d4
Step 11 : CMD ./bin/server
 ---> Running in 9aa0b72d385b
 ---> 403524f90a4f
Removing intermediate container 9aa0b72d385b
Successfully built 403524f90a4f
Recreating pazservicedirectory_svcdir_1...
Creating pazservicedirectory_svcdir_1...


  .......

7 tests complete
Test duration: 212 ms
No global variable leaks detected

Stopping pazservicedirectory_svcdir_1...
```
